### PR TITLE
Fix Resource Loading

### DIFF
--- a/src/dreamlink/disk/Pack.java
+++ b/src/dreamlink/disk/Pack.java
@@ -7,8 +7,8 @@ public class Pack {
     public final String packName;
     public final File file; 
 
-    public Pack(String roomName, File file) {
-        this.packName = roomName;
+    public Pack(String packName, File file) {
+        this.packName = packName;
         this.file = file;
     }
     

--- a/src/dreamlink/disk/PackState.java
+++ b/src/dreamlink/disk/PackState.java
@@ -40,7 +40,9 @@ public class PackState {
                         continue;
                     }
 
-                    try(var stream = classLoader.getResourceAsStream(pack.file.toString())) {
+                    // Windows paths are backslash-separated, but we need forward slashes when using the class loader
+                    var resourcePath = pack.file.toString().replace("\\", "/");
+                    try(var stream = classLoader.getResourceAsStream(resourcePath)) {
                         Files.copy(stream, tempFilePath, StandardCopyOption.REPLACE_EXISTING);
                         FileFns.extractZip(tempFilePath.toFile(), destinationFile);
                     }

--- a/src/dreamlink/overlay/home/edit/HomeEditRoomCreateComponent.java
+++ b/src/dreamlink/overlay/home/edit/HomeEditRoomCreateComponent.java
@@ -41,7 +41,7 @@ public class HomeEditRoomCreateComponent extends WrapperComponent{
             var roomName = HomeEditRoomCreateComponent.this.name;
             var packName = PackState.instance.getPack(HomeEditRoomCreateComponent.this.selectedPackIndex);
             var roomPath = LocalRoomState.instance.addRoom(roomName).file.toPath();
-            FileFns.copyDirectory(packName.file, roomPath.resolve("pack").toFile());
+            FileFns.copyDirectory(packName.packPath, roomPath.resolve("pack").toFile());
             var terrainFile = roomPath.resolve("terrain.dat").toFile();
 
             try(


### PR DESCRIPTION
When loading resources - make sure that we use FORWARD slashes regardless of whether or not we're in Windows. Thus - in the one instance where we use the output of File.toString() to generate a resource path - replace backslashes with forward slashes